### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pip install -e nc2pt/
 
 That's it!
 
-Note: We are currently investigating removing xESMF dependency from this project due to restrictiveness of the conda environment see issue #15 for more info -17/3/2025.
+Note: We are currently investigating removing xESMF dependency from this project due to restrictiveness of the conda environment see [issue #15](https://github.com/climagination/nc2pt/issues/15#issue-2921181147) for more info -17/3/2025.
 
 ### 📋 Configuration
 nc2pt uses [hydra](https://hydra.cc/) for configuring and by instantiating structured classes in `nc2pt/climatedata.py`. This simeultaneously defines the workflow as well as the data. Please see `nc2pt/conf/config.yml` for an example configuration, or below:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ pip install -e nc2pt/
 
 That's it!
 
+Note: We are currently investigating removing xESMF dependency from this project due to restrictiveness of the conda environment see issue #15 for more info -17/3/2025.
+
 ### 📋 Configuration
 nc2pt uses [hydra](https://hydra.cc/) for configuring and by instantiating structured classes in `nc2pt/climatedata.py`. This simeultaneously defines the workflow as well as the data. Please see `nc2pt/conf/config.yml` for an example configuration, or below:
 


### PR DESCRIPTION
Update documentation to include a reference to the ongoing investigation of the xESMF dependency and various methods for bilinear interpolation. 

I put the reference in the same section as the installation instructions as that is where the issue of conda dependencies is discussed. I included a date incase this becomes a dead piece of documentation. Likely the documentation will be updated when xESMF dependencies are removed and the reference to issue #15 will be moved/updated.