### PR TITLE
Crashing worker bug

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,11 +27,11 @@ jobs:
       - run: which python
       - name: Install
         run: |
-          conda install -c conda-forge xesmf
+        #  conda install -c conda-forge xesmf
           conda install -c conda-forge pip
       - name: Set ESMFMKFILE and install reqs
         run: |
-          export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
+        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
           pip install -r requirements.txt
           pip install -e .
       - name: Lint with flake8
@@ -44,13 +44,15 @@ jobs:
       - name: Test with pytest
         run: |
           conda install pytest
-          export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
           pytest nc2pt/tests/
+        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
+          
       - name: Generate coverage reports
         run: |
           conda install pytest-cov
-          export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
           pytest --cov-config=.coveragerc --cov=nc2pt --cov-report=xml nc2pt/tests/
+        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
+          
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,11 +27,9 @@ jobs:
       - run: which python
       - name: Install
         run: |
-        #  conda install -c conda-forge xesmf
           conda install -c conda-forge pip
-      - name: Set ESMFMKFILE and install reqs
+      - name: Install reqs
         run: |
-        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
           pip install -r requirements.txt
           pip install -e .
       - name: Lint with flake8
@@ -45,14 +43,10 @@ jobs:
         run: |
           conda install pytest
           pytest nc2pt/tests/
-        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
-          
       - name: Generate coverage reports
         run: |
           conda install pytest-cov
           pytest --cov-config=.coveragerc --cov=nc2pt --cov-report=xml nc2pt/tests/
-        #  export ESMFMKFILE=/usr/share/miniconda/envs/__setup_conda/lib/esmf.mk
-          
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -171,8 +171,8 @@ def interpolate(ds: xr.Dataset, grid: xr.Dataset) -> xr.Dataset:
         "lon": grid.lon,
     })
     ds = ds.interp(
-        latitude=interp_points["lat"],
-        longitude=interp_points["lon"] + 360,
+        lat=interp_points["lat"],
+        lon=interp_points["lon"],
         method="linear"
     )
     return ds

--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -3,7 +3,6 @@ from typing import Dict
 
 import pandas as pd
 import xarray as xr
-import xesmf as xe
 
 from nc2pt.climatedata import ClimateData
 import omegaconf
@@ -167,8 +166,15 @@ def interpolate(ds: xr.Dataset, grid: xr.Dataset) -> xr.Dataset:
         raise ValueError("lat not in grid dims, check grid")
 
     # Check that the dataset has the correct variables
-    regridder = xe.Regridder(ds, grid, "bilinear")
-    ds = regridder(ds)
+    interp_points = xr.Dataset({
+        "lat": grid.lat,
+        "lon": grid.lon,
+    })
+    ds = ds.interp(
+        latitude=interp_points["lat"],
+        longitude=interp_points["lon"] + 360,
+        method="linear"
+    )
     return ds
 
 

--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 import logging
 from typing import Optional, List, Union
+import xarray as xr
 
 
 @dataclass
@@ -46,3 +47,27 @@ class ClimateData:
     select: dict
     compute: dict
     loader: dict
+
+    def apply_chunks(self, ds: xr.Dataset) -> xr.Dataset:
+        """
+        Apply dimension-aware chunking to an xarray Dataset using the ClimateDimension specs.
+
+        Only includes dimensions that exist in the dataset. Falls back to alternative names.
+        """
+        chunk_dict = {}
+
+        for dim in self.dims:
+            # Check if dim.name or any alternative name is present in the dataset
+            matched_name = next(
+                (name for name in [dim.name] + dim.alternative_names if name in ds.dims),
+                None
+            )
+            if matched_name is not None:
+                chunk_dict[matched_name] = dim.chunksize
+
+        if chunk_dict:
+            logging.info(f"Applying chunks: {chunk_dict}")
+            return ds.chunk(chunk_dict)
+        else:
+            logging.warning("No matching dimensions found for chunking.")
+            return ds

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -39,7 +39,7 @@ def user_defined_transform(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
             return eval(transform)
 
         logging.info(f"Applying transform {transform} to {var.name}...")
-        ds[var.name] = xr.apply_ufunc(func, ds[var.name], dask="parallelized").compute()
+        ds[var.name] = xr.apply_ufunc(func, ds[var.name], dask="parallelized")
 
     return ds
 

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,6 +12,223 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
+output_path: /home/sbeairsto/data-sbeairsto/test_data
+climate_models:
+  #- _target_: nc2pt.climatedata.ClimateModel
+  #  name: hr
+  #  info: "High Resolution USask WRF, Western Canada"
+  #  climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+       #- _target_: nc2pt.climatedata.ClimateVariable
+       #  name: "pr"
+       #  alternative_names: ["PREC"]
+       #  path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
+       #  is_west_negative: true
+       #  apply_standardize: false
+       #  apply_normalize: true
+       #  invariant: false
+       #  transform: []
+
+  #     - _target_: nc2pt.climatedata.ClimateVariable
+  #       name: "uas"
+  #       alternative_names: ["U10", "u10", "uas"]
+  #       path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
+  #       is_west_negative: true
+  #       apply_standardize: false
+  #       apply_normalize: true
+  #       invariant: false
+  #       transform: []
+
+  #     - _target_: nc2pt.climatedata.ClimateVariable
+  #       name: "vas"
+  #       alternative_names: ["V10", "v10", "vas"]
+  #       path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
+  #       is_west_negative: true
+  #       apply_standardize: false
+  #       apply_normalize: true
+  #       invariant: false
+  #       transform: []        
+
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "RH"
+      #   alternative_names: ["rh", "RH", "relative humidity"]
+      #   path: /path/to/my/WRF/relative_humidity/*.nc
+      #   is_west_negative: true
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: []
+
+      #- _target_: nc2pt.climatedata.ClimateVariable
+      #  name: "tas"
+      #  alternative_names: ["T2", "surface temperature"]
+      #  path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/T2/*.nc
+      #  is_west_negative: true
+      #  apply_standardize: false
+      #  apply_normalize: true
+      #  invariant: false
+      #  transform: []
+  
+
+  - _target_: nc2pt.climatedata.ClimateModel
+    info: "Low resolution ERA5, Western Canada"
+    name: lr
+    hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
+      _target_: nc2pt.climatedata.ClimateVariable
+      name: "hr_ref"
+      alternative_names: ["T2"]
+      path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
+      is_west_negative: true
+      invariant: true
+
+    climate_variables:
+       - _target_: nc2pt.climatedata.ClimateVariable
+         name: "uas"
+         alternative_names: ["U10", "u10", "uas"]
+         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+         is_west_negative: false
+         apply_standardize: false
+         apply_normalize: true
+         invariant: false
+         transform: []
+  
+    #   - _target_: nc2pt.climatedata.ClimateVariable
+    #     name: "pr"
+    #     alternative_names: ["PREC"]
+    #     path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
+    #     is_west_negative: false
+    #     apply_standardize: false
+    #     apply_normalize: true
+    #     invariant: false
+    #     transform: ["x * 3600"]
+         #  - "x * 3600"
+
+# # for some reason, the way RH was written to file requires time chunks be explicitly defined in io.py.
+# # Other files will process fine, don't know what to do about this problem...
+#       - _target_: nc2pt.climatedata.ClimateVariable
+#         name: "RH"
+#         alternative_names: ["rh", "huss", "Q2", "q2"]
+#         path: path/to/my/ERA5/relative_humidity/RH.nc
+#         is_west_negative: false
+#         apply_standardize: false
+#         apply_normalize: true
+#         invariant: false
+#         transform: []
+
+#       - _target_: nc2pt.climatedata.ClimateVariable
+#         name: "vas"
+#         alternative_names: ["V10", "v10", "vas"]
+#         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+#         apply_standardize: false
+#         apply_normalize: true
+#         invariant: false
+#         transform: []
+
+#      - _target_: nc2pt.climatedata.ClimateVariable
+#        name: "tas"
+#        alternative_names: ["T2", "surface temperature"]
+#        path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc'
+#        is_west_negative: false
+#        apply_standardize: false
+#        apply_normalize: true
+#        invariant: false
+#        transform: []
+          # - "x - 273.15"
+
+
+dims: # Defines the dimensions of the dataset and lists them to be initialized as ClimateDimension objects
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: time
+    alternative_names: ["forecast_initial_time", "Time", "Times", "times"]
+    chunksize: 100
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: rlat
+    alternative_names: ["rotated_latitude"]
+    hr_only: true
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: rlon
+    alternative_names: ["rotated_longitude"]
+    hr_only: true
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lat
+    alternative_names: ["rotated_latitude"]
+    hr_only: true
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lon
+    alternative_names: ["rotated_latitude"]
+    hr_only: true
+    chunksize: -1
+
+coords:
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: time
+    alternative_names: ["forecast_initial_time", "Time", "Times", "times"]
+    chunksize: 100
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lat
+    alternative_names: ["latitude", "Lat", "Latitude"]
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lon
+    alternative_names: ["longitude", "Long", "Lon", "Longitude"]
+    chunksize: -1
+
+select:
+  # Time indexing for subsets
+  time:
+    # Crop to the dataset with the shortest run
+    # this defines the full dataset from which to subset
+    range:
+      start: "20001001T06:00:00"
+      end: "20010928T12:00:00"
+      # start: "2021-11-01T00:00:00"
+      # end: "2021-12-31T22:00:00"
+
+    # use this to select which years to reserve for testing
+    # and for validation
+    # the remaining years in full will be used for training
+    test_years: [2000]
+    validation_years: [2000]
+    # test_years: [None]
+    # validation_years: [None]
+
+  # sets the scale factor and index slices of the rotated coordinates
+  spatial:
+    scale_factor: 8
+    x:
+      first_index: 110
+      last_index: 622
+    y:
+      first_index: 20
+      last_index: 532
+
+
+
+# dask client parameters
+compute:
+  # xarray netcdf engine
+  engine: h5netcdf
+  dask_dashboard_address: 8787
+  chunks:
+    time: 200
+    rlat: -1
+    rlon: -1
+# If the variables are the same, but are named differently in
+# the netCDF files, use the yaml key as the "homogenizing" key, and
+# list the alternative name in "alternative_names".
+# This pipeline will rename the alternative name to the yaml key if found.
+# E.g. if the lr and hr datasets have different
+# numbers of covariates, e.g. Annau et al. 2023, then
+# you can specify if a variable only occurs in the hr or lr
+# dataset respectively with hr_only or lr_only: true
+# The same logic above applies for the dimensions, dims, and coordinates, coords.
+
+# This defines the pipeline and parameters. Each config defined by a
+# _target_ is loaded as a dataclass in climatedata.py with some inheritance.
+
+_target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
 output_path: /path/to/my/data/folder
 climate_models:
   - _target_: nc2pt.climatedata.ClimateModel
@@ -144,18 +361,24 @@ dims: # Defines the dimensions of the dataset and lists them to be initialized a
     name: rlat
     alternative_names: ["rotated_latitude"]
     hr_only: true
-    chunksize: 100
+    chunksize: -1
   - _target_: nc2pt.climatedata.ClimateDimension
     name: rlon
     alternative_names: ["rotated_longitude"]
     hr_only: true
-    chunksize: 100
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lat
+    alternative_names: ["latitude", "Lat", "Latitude"]
+    hr_only: false
+    chunksize: -1
+  - _target_: nc2pt.climatedata.ClimateDimension
+    name: lon
+    alternative_names: ["longitude", "Long", "Lon", "Longitude"]
+    hr_only: false
+    chunksize: -1
 
 coords:
-  - _target_: nc2pt.climatedata.ClimateDimension
-    name: time
-    alternative_names: ["forecast_initial_time", "Time", "Times", "times"]
-    chunksize: 100
   - _target_: nc2pt.climatedata.ClimateDimension
     name: lat
     alternative_names: ["latitude", "Lat", "Latitude"]
@@ -203,9 +426,14 @@ compute:
   dask_dashboard_address: 8787
   chunks:
     time: 100
-    rlat: 100
-    rlon: 100
+    rlat: -1
+    rlon: -1
 
+# for tools scripts
+loader:
+  batch_size: 4
+  randomize: true
+  seed: 0
 # for tools scripts
 loader:
   batch_size: 4

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,7 +12,7 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
-output_path: /home/sbeairsto/data/data-sbeairsto
+output_path: /path/to/my/data/folder
 climate_models:
   - _target_: nc2pt.climatedata.ClimateModel
     name: hr

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -76,7 +76,7 @@ climate_models:
       _target_: nc2pt.climatedata.ClimateVariable
       name: "hr_ref"
       alternative_names: ["T2"]
-      path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
+      path: /home/my_username/nc2pt/nc2pt/data/hr_ref.nc
       is_west_negative: true
       invariant: true
 

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,36 +12,36 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
-output_path: /home/sbeairsto/data/proc/
+output_path: /home/sbeairsto/data/data-sbeairsto
 climate_models:
-  #- _target_: nc2pt.climatedata.ClimateModel
-  #  name: hr
-  #  info: "High Resolution USask WRF, Western Canada"
-  #  climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
-  #     - _target_: nc2pt.climatedata.ClimateVariable
-  #       name: "pr"
-  #       alternative_names: ["PREC"]
-  #       path:  /home/nannau/USask-WRF-WCA/fire_vars/PREC/*.nc
-  #       is_west_negative: true
-  #       apply_standardize: false
-  #       apply_normalize: true
-  #       invariant: false
-  #       transform: []
+  - _target_: nc2pt.climatedata.ClimateModel
+    name: hr
+    info: "High Resolution USask WRF, Western Canada"
+    climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+       - _target_: nc2pt.climatedata.ClimateVariable
+         name: "pr"
+         alternative_names: ["PREC"]
+         path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
+         is_west_negative: true
+         apply_standardize: false
+         apply_normalize: true
+         invariant: false
+         transform: []
 
-  #     - _target_: nc2pt.climatedata.ClimateVariable
-  #       name: "uas"
-  #       alternative_names: ["U10", "u10", "uas"]
-  #       path: /home/nannau/USask-WRF-WCA/fire_vars/U10/*.nc
-  #       is_west_negative: true
-  #       apply_standardize: false
-  #       apply_normalize: true
-  #       invariant: false
-  #       transform: []
+       - _target_: nc2pt.climatedata.ClimateVariable
+         name: "uas"
+         alternative_names: ["U10", "u10", "uas"]
+         path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
+         is_west_negative: true
+         apply_standardize: false
+         apply_normalize: true
+         invariant: false
+         transform: []
 
   #     - _target_: nc2pt.climatedata.ClimateVariable
   #       name: "vas"
   #       alternative_names: ["V10", "v10", "vas"]
-  #       path: /home/nannau/USask-WRF-WCA/fire_vars/V10/*.nc
+  #       path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
   #       is_west_negative: true
   #       apply_standardize: false
   #       apply_normalize: true
@@ -51,7 +51,7 @@ climate_models:
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "RH"
       #   alternative_names: ["rh", "RH", "relative humidity"]
-      #   path: /home/nannau/USask-WRF-WCA/fire_vars/RH/*.nc
+      #   path: /path/to/my/WRF/relative_humidity/*.nc
       #   is_west_negative: true
       #   apply_standardize: false
       #   apply_normalize: true
@@ -61,7 +61,7 @@ climate_models:
       #- _target_: nc2pt.climatedata.ClimateVariable
       #  name: "tas"
       #  alternative_names: ["T2", "surface temperature"]
-      #  path: /home/nannau/USask-WRF-WCA/fire_vars/T2/*.nc
+      #  path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/T2/*.nc
       #  is_west_negative: true
       #  apply_standardize: false
       #  apply_normalize: true
@@ -81,33 +81,33 @@ climate_models:
       invariant: true
 
     climate_variables:
-       - _target_: nc2pt.climatedata.ClimateVariable
-         name: "uas"
-         alternative_names: ["U10", "u10", "uas"]
-         path: /home/sbeairsto/downloads-sbeairsto/ERA5/u10*.nc
-         is_west_negative: false
-         apply_standardize: false
-         apply_normalize: true
-         invariant: false
-         transform: []
-  
 #       - _target_: nc2pt.climatedata.ClimateVariable
-#         name: "pr"
-#         alternative_names: ["PREC"]
-#         path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106_time_sliced_cropped_merged_forecast_time.nc
+#         name: "uas"
+#         alternative_names: ["U10", "u10", "uas"]
+#         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
 #         is_west_negative: false
 #         apply_standardize: false
 #         apply_normalize: true
 #         invariant: false
-#         transform:
-#           - "x * 3600"
+#         transform: []
+  
+       - _target_: nc2pt.climatedata.ClimateVariable
+         name: "pr"
+         alternative_names: ["PREC"]
+         path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
+         is_west_negative: false
+         apply_standardize: false
+         apply_normalize: true
+         invariant: false
+         transform: ["x * 3600"]
+         #  - "x * 3600"
 
 # # for some reason, the way RH was written to file requires time chunks be explicitly defined in io.py.
 # # Other files will process fine, don't know what to do about this problem...
 #       - _target_: nc2pt.climatedata.ClimateVariable
 #         name: "RH"
 #         alternative_names: ["rh", "huss", "Q2", "q2"]
-#         path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/rh_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
+#         path: path/to/my/ERA5/relative_humidity/RH.nc
 #         is_west_negative: false
 #         apply_standardize: false
 #         apply_normalize: true
@@ -117,22 +117,21 @@ climate_models:
 #       - _target_: nc2pt.climatedata.ClimateVariable
 #         name: "vas"
 #         alternative_names: ["V10", "v10", "vas"]
-#         path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
-#         is_west_negative: false
+#         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
 #         apply_standardize: false
 #         apply_normalize: true
 #         invariant: false
 #         transform: []
 
-      #- _target_: nc2pt.climatedata.ClimateVariable
-        #name: "tas"
-        #alternative_names: ["T2", "surface temperature"]
-        #path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
-        #is_west_negative: false
-        #apply_standardize: false
-        #apply_normalize: true
-        #invariant: false
-        #transform: []
+#      - _target_: nc2pt.climatedata.ClimateVariable
+#        name: "tas"
+#        alternative_names: ["T2", "surface temperature"]
+#        path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc'
+#        is_west_negative: false
+#        apply_standardize: false
+#        apply_normalize: true
+#        invariant: false
+#        transform: []
           # - "x - 273.15"
 
 
@@ -180,8 +179,8 @@ select:
     # use this to select which years to reserve for testing
     # and for validation
     # the remaining years in full will be used for training
-    test_years: [2000,2003,2004]
-    validation_years: [2001]
+    test_years: [2000, 2009, 2014]
+    validation_years: [2015]
     # test_years: [None]
     # validation_years: [None]
 

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,12 +12,12 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
-output_path: /home/nannau/data/proc/
+output_path: /home/sbeairsto/data/proc/
 climate_models:
-  - _target_: nc2pt.climatedata.ClimateModel
-    name: hr
-    info: "High Resolution USask WRF, Western Canada"
-    climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+  #- _target_: nc2pt.climatedata.ClimateModel
+  #  name: hr
+  #  info: "High Resolution USask WRF, Western Canada"
+  #  climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
   #     - _target_: nc2pt.climatedata.ClimateVariable
   #       name: "pr"
   #       alternative_names: ["PREC"]
@@ -58,15 +58,15 @@ climate_models:
       #   invariant: false
       #   transform: []
 
-      - _target_: nc2pt.climatedata.ClimateVariable
-        name: "tas"
-        alternative_names: ["T2", "surface temperature"]
-        path: /home/nannau/USask-WRF-WCA/fire_vars/T2/*.nc
-        is_west_negative: true
-        apply_standardize: false
-        apply_normalize: true
-        invariant: false
-        transform: []
+      #- _target_: nc2pt.climatedata.ClimateVariable
+      #  name: "tas"
+      #  alternative_names: ["T2", "surface temperature"]
+      #  path: /home/nannau/USask-WRF-WCA/fire_vars/T2/*.nc
+      #  is_west_negative: true
+      #  apply_standardize: false
+      #  apply_normalize: true
+      #  invariant: false
+      #  transform: []
   
 
   - _target_: nc2pt.climatedata.ClimateModel
@@ -76,20 +76,20 @@ climate_models:
       _target_: nc2pt.climatedata.ClimateVariable
       name: "hr_ref"
       alternative_names: ["T2"]
-      path: /home/nannau/nc2pt/nc2pt/data/hr_ref.nc
+      path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
       is_west_negative: true
       invariant: true
 
     climate_variables:
-#       - _target_: nc2pt.climatedata.ClimateVariable
-#         name: "uas"
-#         alternative_names: ["U10", "u10", "uas"]
-#         path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
-#         is_west_negative: false
-#         apply_standardize: false
-#         apply_normalize: true
-#         invariant: false
-#         transform: []
+       - _target_: nc2pt.climatedata.ClimateVariable
+         name: "uas"
+         alternative_names: ["U10", "u10", "uas"]
+         path: /home/sbeairsto/downloads-sbeairsto/ERA5/u10*.nc
+         is_west_negative: false
+         apply_standardize: false
+         apply_normalize: true
+         invariant: false
+         transform: []
   
 #       - _target_: nc2pt.climatedata.ClimateVariable
 #         name: "pr"
@@ -124,15 +124,15 @@ climate_models:
 #         invariant: false
 #         transform: []
 
-      - _target_: nc2pt.climatedata.ClimateVariable
-        name: "tas"
-        alternative_names: ["T2", "surface temperature"]
-        path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
-        is_west_negative: false
-        apply_standardize: false
-        apply_normalize: true
-        invariant: false
-        transform: []
+      #- _target_: nc2pt.climatedata.ClimateVariable
+        #name: "tas"
+        #alternative_names: ["T2", "surface temperature"]
+        #path: /home/nannau/ERA5_NCAR-RDA_North_America/proc/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123_time_sliced_cropped.nc
+        #is_west_negative: false
+        #apply_standardize: false
+        #apply_normalize: true
+        #invariant: false
+        #transform: []
           # - "x - 273.15"
 
 
@@ -140,27 +140,27 @@ dims: # Defines the dimensions of the dataset and lists them to be initialized a
   - _target_: nc2pt.climatedata.ClimateDimension
     name: time
     alternative_names: ["forecast_initial_time", "Time", "Times", "times"]
-    chunksize: auto
+    chunksize: 100
   - _target_: nc2pt.climatedata.ClimateDimension
     name: rlat
     alternative_names: ["rotated_latitude"]
     hr_only: true
-    chunksize: auto
+    chunksize: 100
   - _target_: nc2pt.climatedata.ClimateDimension
     name: rlon
     alternative_names: ["rotated_longitude"]
     hr_only: true
-    chunksize: auto
+    chunksize: 100
 
 coords:
   - _target_: nc2pt.climatedata.ClimateDimension
     name: lat
     alternative_names: ["latitude", "Lat", "Latitude"]
-    chunksize: auto
+    chunksize: 100
   - _target_: nc2pt.climatedata.ClimateDimension
     name: lon
     alternative_names: ["longitude", "Long", "Lon", "Longitude"]
-    chunksize: auto
+    chunksize: 100
 
 select:
   # Time indexing for subsets
@@ -169,15 +169,15 @@ select:
     # this defines the full dataset from which to subset
     range:
       start: "20001001T06:00:00"
-      end: "20150928T12:00:00"
+      end: "20040928T12:00:00"
       # start: "2021-11-01T00:00:00"
       # end: "2021-12-31T22:00:00"
 
     # use this to select which years to reserve for testing
     # and for validation
     # the remaining years in full will be used for training
-    test_years: [2000, 2009, 2014]
-    validation_years: [2015]
+    test_years: [2000]
+    validation_years: [2001]
     # test_years: [None]
     # validation_years: [None]
 
@@ -199,9 +199,9 @@ compute:
   engine: h5netcdf
   dask_dashboard_address: 8787
   chunks:
-    time: auto
-    rlat: auto
-    rlon: auto
+    time: 100
+    rlat: 100
+    rlon: 100
 
 # for tools scripts
 loader:

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -154,6 +154,10 @@ dims: # Defines the dimensions of the dataset and lists them to be initialized a
 
 coords:
   - _target_: nc2pt.climatedata.ClimateDimension
+    name: time
+    alternative_names: ["forecast_initial_time", "Time", "Times", "times"]
+    chunksize: 100
+  - _target_: nc2pt.climatedata.ClimateDimension
     name: lat
     alternative_names: ["latitude", "Lat", "Latitude"]
     chunksize: 100
@@ -169,14 +173,14 @@ select:
     # this defines the full dataset from which to subset
     range:
       start: "20001001T06:00:00"
-      end: "20040928T12:00:00"
+      end: "20150928T12:00:00"
       # start: "2021-11-01T00:00:00"
       # end: "2021-12-31T22:00:00"
 
     # use this to select which years to reserve for testing
     # and for validation
     # the remaining years in full will be used for training
-    test_years: [2000]
+    test_years: [2000,2003,2004]
     validation_years: [2001]
     # test_years: [None]
     # validation_years: [None]

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -36,6 +36,11 @@ def configure_metadata(
     logging.info("✨ Homogenizing dataset keys...")
 
     dim_coord_attrs = {"coords": climdata.coords, "dims": climdata.dims}
+
+    if "forecast_initial_time" in ds.dims and "forecast_hour" in ds.dims:
+        # Flatten 2D time coordinates found in ERA5 PR nc files
+        ds = flatten_2D_forecast_time(ds=ds)
+
     for ds_attr, dim_or_coord in dim_coord_attrs.items():
         ds = loop_over_keys_and_rename(ds, dim_or_coord, ds_attr)
 
@@ -131,4 +136,27 @@ def match_longitudes(ds: xr.Dataset) -> xr.Dataset:
             "which is the intention of this function. Check longitude units."
         )
     ds = ds.assign_coords(lon=(ds.lon + 360))
+    return ds
+
+
+def flatten_2D_forecast_time(ds: xr.Dataset) -> xr.Dataset:
+    """Flatten forecast_initial_time and forecast_hour into a
+      single time coordinate (seems to be structure of ERA5 PR data).
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Dataset containing 'forecast_initial_time' and 'forecast_hour'.
+
+    Returns
+    -------
+    ds : xarray.Dataset
+        Dataset with stacked 'time' dimension based on valid forecast time.
+    """
+    init, hour = xr.broadcast(ds.forecast_initial_time, ds.forecast_hour)
+    valid_time = init + hour.astype("timedelta64[ns]")
+    ds = ds.stack(time=("forecast_initial_time", "forecast_hour"))
+    ds = ds.drop_vars(["time", "forecast_initial_time", "forecast_hour"])
+    ds = ds.assign_coords(time=("time", valid_time.values.ravel()))
+    ds = ds.assign_coords(time=("time", valid_time.values.ravel()))
     return ds

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -42,8 +42,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
     for climate_variable in model.climate_variables:
         # Instantiates climate_variable object in cliamtedata.py
         climate_variable = instantiate(climate_variable)
-        chunk_dims = {dim.name: dim.chunksize for dim in climdata.dims}
-        chunk_coords = {coord.name: coord.chunksize for coord in climdata.coords}
+
         ds = load_grid(climate_variable.path, engine=climdata.compute.engine)
 
         start = timer()
@@ -52,12 +51,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         ds = configure_metadata_fn(ds, climate_variable)
-        if 'rlat' in ds.dims:
-            ds = ds.chunk(chunk_dims)
-        elif 'lat' in ds.dims:
-            ds = ds.chunk(chunk_coords)
-        else:
-            raise ValueError("Dataset must have either 'lat' or 'rlat' in its dimensions.")
+        ds = climdata.apply_chunks(ds)
 
         ds = (
             slice_time(
@@ -91,14 +85,14 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
             for train_test_validation in train_test_validation_ds:
                 logging.info(f"✨ Writing {train_test_validation} output...")
                 write_to_zarr(
-                    train_test_validation_ds[train_test_validation].chunk(chunk_dims),
+                    climdata.apply_chunks(train_test_validation_ds[train_test_validation]),
                     f"{climdata.output_path}/{climate_variable.name}_{train_test_validation}_{model.name}",
                 )
 
         else:
             logging.info("✨ Writing output...")
             write_to_zarr(
-                ds.chunk(chunk_dims),
+                climdata.apply_chunks(ds),
                 f"{climdata.output_path}/{climate_variable.name}_{model.name}",
             )
 

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -52,7 +52,13 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         ds = configure_metadata_fn(ds, climate_variable)
-        ds = ds.chunk(chunk_coords)
+        if 'rlat' in ds.dims:
+            ds = ds.chunk(chunk_dims)
+        elif 'lat' in ds.dims:
+            ds = ds.chunk(chunk_coords)
+        else:
+            raise ValueError("Dataset must have either 'lat' or 'rlat' in its dimensions.")
+
         ds = (
             slice_time(
                 ds, climdata.select.time.range.start, climdata.select.time.range.end

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -43,6 +43,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         # Instantiates climate_variable object in cliamtedata.py
         climate_variable = instantiate(climate_variable)
         chunk_dims = {dim.name: dim.chunksize for dim in climdata.dims}
+        chunk_coords = {coord.name: coord.chunksize for coord in climdata.coords}
         ds = load_grid(climate_variable.path, engine=climdata.compute.engine)
 
         start = timer()
@@ -51,7 +52,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         ds = configure_metadata_fn(ds, climate_variable)
-        ds = ds.chunk(chunk_dims)
+        ds = ds.chunk(chunk_coords)
         ds = (
             slice_time(
                 ds, climdata.select.time.range.start, climdata.select.time.range.end

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -51,6 +51,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         ds = configure_metadata_fn(ds, climate_variable)
+        ds = ds.chunk(chunk_dims)
         ds = (
             slice_time(
                 ds, climdata.select.time.range.start, climdata.select.time.range.end


### PR DESCRIPTION
### 🛠️ Summary of Changes
This PR removes the dependency on `xESMF`, replacing it with native `xarray` interpolation for regridding low-resolution ERA5 data to match high-resolution WRF grids.

### 🔧 Key Modifications
- Removed:

```
regridder = xe.Regridder(ds, grid, "bilinear")
ds = regridder(ds)
```

Replaced with:

```
interp_points = xr.Dataset({"lat": grid.lat, "lon": grid.lon})
ds = ds.interp(lat=interp_points["lat"], lon=interp_points["lon"], method="linear")
```
- Also added a `flatten_2D_forecast_time` function in `metadata.py` to support 2D time dimensions present in certain ERA5 PR datasets.

- Updated config paths and chunking options for better performance on memory-limited systems.

- Removed `.compute()` from `xr.apply_ufunc()` to reduce peak memory usage during preprocessing.

### 📚 Motivation
This PR addresses:

[#13](https://github.com/climagination/nc2pt/issues/13): Memory overload and Dask worker crashes during Zarr output on lower-memory systems (Marvin and Tars).

[#15](https://github.com/climagination/nc2pt/issues/15): Proposal to drop `xESMF` due to its Conda-only `esmpy` dependency, which blocks pip-based installs and limits portability.

### 📈 Scientific Justification
As shown in comparative tests:

Max relative differences in the 95th percentile between xESMF and xarray interpolation were ~0.0086%.

Even for the 5th percentile (sensitive to small precipitation values), max difference was ~1.3%, which is acceptable for our use case.

Thus, `xarray.interp()` is sufficiently accurate for WRF/ERA5 applications, especially since interpolated data is subsequently coarsened.

### This update has been successfully tested with:

ERA5 variables: pr, tas, uas, vas

WRF variables: pr, tas, uas, vas
All preprocessing steps completed without memory issues on Marvin and produced expected Zarr outputs.

### 📉 Performance Gains
Reduces the Dask task graph size.

Allows nc2pt to run reliably on systems with ~10–11 GB RAM.

Unlocks support for pip-based installation.

✅ Next Steps
 Update documentation to reflect the new regridding method (see #16, #17).