### PR TITLE
add a line that creates parent directory for pt outputs if it dont al…

### DIFF
--- a/nc2pt/tools/zarr_to_torch.py
+++ b/nc2pt/tools/zarr_to_torch.py
@@ -69,9 +69,9 @@ def loop_over_sets(climate_data, model, s):
             train_ds = xr.open_zarr(train_file)
             train_attrs = train_ds[var.name].attrs
             # now write the attributes to a yaml file
-            train_attrs_file = (
-                f"{climate_data.output_path}/{s}/{var.name}_{s}_{model.name}_attrs.yaml"
-            )
+            train_dir = f"{climate_data.output_path}/{s}"
+            os.makedirs(train_dir, exist_ok=True)
+            train_attrs_file = f"{train_dir}/{var.name}_{s}_{model.name}_attrs.yaml"
             with open(train_attrs_file, "w") as file:
                 file.write("attributes:\n")
                 for key, value in train_attrs.items():

--- a/nc2pt/tools/zarr_to_torch.py
+++ b/nc2pt/tools/zarr_to_torch.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta
 from timeit import default_timer as timer
 from functools import partial
+from pathlib import Path
 
 import xarray as xr
 import torch
@@ -69,9 +70,10 @@ def loop_over_sets(climate_data, model, s):
             train_ds = xr.open_zarr(train_file)
             train_attrs = train_ds[var.name].attrs
             # now write the attributes to a yaml file
-            train_dir = f"{climate_data.output_path}/{s}"
-            os.makedirs(train_dir, exist_ok=True)
-            train_attrs_file = f"{train_dir}/{var.name}_{s}_{model.name}_attrs.yaml"
+            train_dir = Path(f"{climate_data.output_path}/{s}")
+            train_dir.mkdir(parents=True, exist_ok=True)
+
+            train_attrs_file = train_dir / f"{var.name}_{s}_{model.name}_attrs.yaml"
             with open(train_attrs_file, "w") as file:
                 file.write("attributes:\n")
                 for key, value in train_attrs.items():


### PR DESCRIPTION
### Description:

This PR addresses [Issue #20](https://github.com/your-repo-name/issues/20), which caused a `FileNotFoundError` when attempting to write variable attribute YAML files to non-existent `train/`, `test/`, or `validation/` directories.

### Change Summary

- Added a `pathlib`-based workflow in `loop_over_sets()` in `zarr_to_torch.py` to ensure the output directory exists before writing:
  
  ```python
  train_dir = Path(f"{climate_data.output_path}/{s}")
  train_dir.mkdir(parents=True, exist_ok=True)

  train_attrs_file = train_dir / f"{var.name}_{s}_{model.name}_attrs.yaml"
  ```
  
- This replaces a previous version of this PR which was using `os.makedirs()` and manual string concatenation with a cleaner, more portable approach.