### PR TITLE
Invariant field support issue #32

### DIFF
--- a/nc2pt/align.py
+++ b/nc2pt/align.py
@@ -88,7 +88,7 @@ def train_test_split(
     return {"train": train, "test": test, "validation": validation}
 
 
-def crop_field(ds, scale_factor, x, y):
+def crop_field(ds, scale_factor, x, y, downsample=False):
     """Crop the field to the given size.
 
     Parameters
@@ -126,6 +126,11 @@ def crop_field(ds, scale_factor, x, y):
     assert (
         ds.rlon.size == ds.rlat.size
     ), "rlon and rlat not the same size, check dataset"
+
+    if downsample:
+        # Optional coarsen for low resolution invariant fields.
+        logging.info("🌎 Coarsening HR invariant to become LR invariant...")
+        ds = coarsen_lr(ds, scale_factor)
 
     return ds
 

--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -33,6 +33,7 @@ class ClimateModel:
     info: str
     climate_variables: List[ClimateVariable]
     hr_ref: Optional[ClimateVariable] = None
+    engine: Optional[str] = None  # Optional engine override for this model
 
     def __post_init__(self):
         logging.info(f"🌎 Instantiated Model with information: {self.info}")

--- a/nc2pt/climatedata.py
+++ b/nc2pt/climatedata.py
@@ -34,6 +34,7 @@ class ClimateModel:
     climate_variables: List[ClimateVariable]
     hr_ref: Optional[ClimateVariable] = None
     engine: Optional[str] = None  # Optional engine override for this model
+    downsample: Optional[bool] = False  # Optional downsampling for invariant fields
 
     def __post_init__(self):
         logging.info(f"🌎 Instantiated Model with information: {self.info}")

--- a/nc2pt/computations.py
+++ b/nc2pt/computations.py
@@ -190,3 +190,42 @@ def split_and_standardize(ds, climdata, var) -> dict:
         }
 
     return {"train": train, "test": test, "validation": validation}
+
+
+def standardize_or_normalize(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
+    """
+    Apply user-defined transformation, standardization, and normalization
+    to a dataset for a given ClimateVariable.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The input dataset containing the variable to transform.
+    var : ClimateVariable
+        The ClimateVariable object containing transformation and scaling flags.
+
+    Returns
+    -------
+    xr.Dataset
+        The dataset with the variable transformed, standardized, and/or normalized.
+
+    Notes
+    -----
+    - Applies a user-defined transformation first (if any).
+    - Standardization and normalization are applied in sequence.
+    - If neither is requested, logs that the step was skipped.
+    """
+    ds = user_defined_transform(ds, var)
+
+    if var.apply_standardize:
+        logging.info(f"Standardizing {var.name}...")
+        ds = compute_standardization(ds, var.name)
+
+    if var.apply_normalize:
+        logging.info(f"Normalizing {var.name}...")
+        ds = compute_normalization(ds, var.name)
+
+    if not var.apply_standardize and not var.apply_normalize:
+        logging.info(f"Skipping standardization and normalization for {var.name}.")
+
+    return ds

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -135,6 +135,21 @@ climate_models:
           # - "x - 273.15"
 
 
+  - _target_: nc2pt.climatedata.ClimateModel
+    name: invariant
+    info: "Static invariant fields for WRF domain"
+    climate_variables:
+      - _target_: nc2pt.climatedata.ClimateVariable
+        name: "HGT"
+        alternative_names: ["HGT", "elevation"]
+        path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/CA4km_const.nc
+        is_west_negative: false
+        invariant: true
+        apply_standardize: false
+        apply_normalize: false
+        transform: []
+
+
 dims: # Defines the dimensions of the dataset and lists them to be initialized as ClimateDimension objects
   - _target_: nc2pt.climatedata.ClimateDimension
     name: time

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,41 +12,41 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
-output_path: /home/sbeairsto/data-sbeairsto/vancouver_island
+output_path: /home/path/to/my/data
 climate_models:
-  # - _target_: nc2pt.climatedata.ClimateModel
-  #   name: hr
-  #   info: "High Resolution USask WRF, Western Canada"
-  #   climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+  - _target_: nc2pt.climatedata.ClimateModel
+    name: hr
+    info: "High Resolution USask WRF, Western Canada"
+    climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+      - _target_: nc2pt.climatedata.ClimateVariable
+        name: "pr"
+        alternative_names: ["PREC"]
+        path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
+        is_west_negative: true
+        apply_standardize: false
+        apply_normalize: true
+        invariant: false
+        transform: []
+
       # - _target_: nc2pt.climatedata.ClimateVariable
-      #   name: "pr"
-      #   alternative_names: ["PREC"]
-      #   path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
+      #   name: "uas"
+      #   alternative_names: ["U10", "u10", "uas"]
+      #   path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
       #   is_west_negative: true
       #   apply_standardize: false
       #   apply_normalize: true
       #   invariant: false
       #   transform: []
 
-    #   - _target_: nc2pt.climatedata.ClimateVariable
-    #     name: "uas"
-    #     alternative_names: ["U10", "u10", "uas"]
-    #     path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
-    #     is_west_negative: true
-    #     apply_standardize: false
-    #     apply_normalize: true
-    #     invariant: false
-    #     transform: []
-
-      #  - _target_: nc2pt.climatedata.ClimateVariable
-      #    name: "vas"
-      #    alternative_names: ["V10", "v10", "vas"]
-      #    path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
-      #    is_west_negative: true
-      #    apply_standardize: false
-      #    apply_normalize: true
-      #    invariant: false
-      #    transform: []        
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "vas"
+      #   alternative_names: ["V10", "v10", "vas"]
+      #   path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
+      #   is_west_negative: true
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: []        
 
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "RH"
@@ -58,81 +58,81 @@ climate_models:
       #   invariant: false
       #   transform: []
 
-      #- _target_: nc2pt.climatedata.ClimateVariable
-      #  name: "tas"
-      #  alternative_names: ["T2", "surface temperature"]
-      #  path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/T2/*.nc
-      #  is_west_negative: true
-      #  apply_standardize: false
-      #  apply_normalize: true
-      #  invariant: false
-      #  transform: []
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "tas"
+      #   alternative_names: ["T2", "surface temperature"]
+      #   path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/T2/*.nc
+      #   is_west_negative: true
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: []
   
 
-  # - _target_: nc2pt.climatedata.ClimateModel
-  #   info: "Low resolution ERA5, Western Canada"
-  #   name: lr
-  #   hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
-  #     _target_: nc2pt.climatedata.ClimateVariable
-  #     name: "hr_ref"
-  #     alternative_names: ["T2"]
-  #     path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
-  #     is_west_negative: true
-  #     invariant: true
+  - _target_: nc2pt.climatedata.ClimateModel
+    info: "Low resolution ERA5, Western Canada"
+    name: lr
+    hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
+      _target_: nc2pt.climatedata.ClimateVariable
+      name: "hr_ref"
+      alternative_names: ["T2"]
+      path: /home/username/projects/nc2pt/nc2pt/data/hr_ref.nc
+      is_west_negative: true
+      invariant: true
 
-  #   climate_variables:
+    climate_variables:
+        - _target_: nc2pt.climatedata.ClimateVariable
+          name: "uas"
+          alternative_names: ["U10", "u10", "uas"]
+          path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+          is_west_negative: false
+          apply_standardize: false
+          apply_normalize: true
+          invariant: false
+          transform: []
+  
   #       - _target_: nc2pt.climatedata.ClimateVariable
-  #         name: "uas"
-  #         alternative_names: ["U10", "u10", "uas"]
-  #         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+  #         name: "pr"
+  #         alternative_names: ["PREC"]
+  #         path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
+  #         is_west_negative: false
+  #         apply_standardize: false
+  #         apply_normalize: true
+  #         invariant: false
+  #         transform: ["x * 3600"]
+  #           - "x * 3600"
+
+  # # for some reason, the way RH was written to file requires time chunks be explicitly defined in io.py.
+  # # Other files will process fine, don't know what to do about this problem...
+  #       - _target_: nc2pt.climatedata.ClimateVariable
+  #         name: "RH"
+  #         alternative_names: ["rh", "huss", "Q2", "q2"]
+  #         path: path/to/my/ERA5/relative_humidity/RH.nc
   #         is_west_negative: false
   #         apply_standardize: false
   #         apply_normalize: true
   #         invariant: false
   #         transform: []
-  
-      # - _target_: nc2pt.climatedata.ClimateVariable
-      #   name: "pr"
-      #   alternative_names: ["PREC"]
-      #   path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
-      #   is_west_negative: false
-      #   apply_standardize: false
-      #   apply_normalize: true
-      #   invariant: false
-      #   transform: ["x * 3600"]
-         #  - "x * 3600"
 
-# # for some reason, the way RH was written to file requires time chunks be explicitly defined in io.py.
-# # Other files will process fine, don't know what to do about this problem...
-#       - _target_: nc2pt.climatedata.ClimateVariable
-#         name: "RH"
-#         alternative_names: ["rh", "huss", "Q2", "q2"]
-#         path: path/to/my/ERA5/relative_humidity/RH.nc
-#         is_west_negative: false
-#         apply_standardize: false
-#         apply_normalize: true
-#         invariant: false
-#         transform: []
+  #       - _target_: nc2pt.climatedata.ClimateVariable
+  #         name: "vas"
+  #         alternative_names: ["V10", "v10", "vas"]
+  #         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+  #         apply_standardize: false
+  #         apply_normalize: true
+  #         invariant: false
+  #         transform: []
 
-  # - _target_: nc2pt.climatedata.ClimateVariable
-  #   name: "vas"
-  #   alternative_names: ["V10", "v10", "vas"]
-  #   path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
-  #   apply_standardize: false
-  #   apply_normalize: true
-  #   invariant: false
-  #   transform: []
-
-#      - _target_: nc2pt.climatedata.ClimateVariable
-#        name: "tas"
-#        alternative_names: ["T2", "surface temperature"]
-#        path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc'
-#        is_west_negative: false
-#        apply_standardize: false
-#        apply_normalize: true
-#        invariant: false
-#        transform: []
-          # - "x - 273.15"
+  #       - _target_: nc2pt.climatedata.ClimateVariable
+  #         name: "tas"
+  #         alternative_names: ["T2", "surface temperature"]
+  #         path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/tas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc'
+  #         is_west_negative: false
+  #         apply_standardize: false
+  #         apply_normalize: true
+  #         invariant: false
+  #         transform: []
+  #             - "x - 273.15"
 
 
   - _target_: nc2pt.climatedata.ClimateModel
@@ -142,7 +142,7 @@ climate_models:
     climate_variables:
       - _target_: nc2pt.climatedata.ClimateVariable
         name: "topography"
-        alternative_names: ["HGT", "elevation"]
+        alternative_names: ["HGT"]
         path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/CA4km_const.nc
         is_west_negative: false
         invariant: true
@@ -209,16 +209,16 @@ select:
     # Crop to the dataset with the shortest run
     # this defines the full dataset from which to subset
     range:
-      start: "20010101T00:00:00"
-      end: "20031231T23:00:00"
+      start: "20001001T06:00:00"
+      end: "20150928T12:00:00"
       # start: "2021-11-01T00:00:00"
       # end: "2021-12-31T22:00:00"
 
     # use this to select which years to reserve for testing
     # and for validation
     # the remaining years in full will be used for training
-    test_years: [2001]
-    validation_years: [2002]
+    test_years: [2000, 2009, 2014]
+    validation_years: [2015]
     # test_years: [None]
     # validation_years: [None]
 
@@ -226,12 +226,11 @@ select:
   spatial:
     scale_factor: 8
     x:
-      first_index: 100
-      last_index: 228
+      first_index: 110
+      last_index: 622
     y:
-      first_index: 0
-      last_index: 128
-
+      first_index: 20
+      last_index: 532
 
 
 # dask client parameters

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -14,10 +14,10 @@
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
 output_path: /home/sbeairsto/data-sbeairsto/vancouver_island
 climate_models:
-  #- _target_: nc2pt.climatedata.ClimateModel
-  #  name: hr
-  #  info: "High Resolution USask WRF, Western Canada"
-  #  climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+  # - _target_: nc2pt.climatedata.ClimateModel
+  #   name: hr
+  #   info: "High Resolution USask WRF, Western Canada"
+  #   climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "pr"
       #   alternative_names: ["PREC"]
@@ -28,25 +28,25 @@ climate_models:
       #   invariant: false
       #   transform: []
 
-      # - _target_: nc2pt.climatedata.ClimateVariable
-      #   name: "uas"
-      #   alternative_names: ["U10", "u10", "uas"]
-      #   path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
-      #   is_west_negative: true
-      #   apply_standardize: false
-      #   apply_normalize: true
-      #   invariant: false
-      #   transform: []
+    #   - _target_: nc2pt.climatedata.ClimateVariable
+    #     name: "uas"
+    #     alternative_names: ["U10", "u10", "uas"]
+    #     path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
+    #     is_west_negative: true
+    #     apply_standardize: false
+    #     apply_normalize: true
+    #     invariant: false
+    #     transform: []
 
-  #     - _target_: nc2pt.climatedata.ClimateVariable
-  #       name: "vas"
-  #       alternative_names: ["V10", "v10", "vas"]
-  #       path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
-  #       is_west_negative: true
-  #       apply_standardize: false
-  #       apply_normalize: true
-  #       invariant: false
-  #       transform: []        
+      #  - _target_: nc2pt.climatedata.ClimateVariable
+      #    name: "vas"
+      #    alternative_names: ["V10", "v10", "vas"]
+      #    path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/V10/*.nc
+      #    is_west_negative: true
+      #    apply_standardize: false
+      #    apply_normalize: true
+      #    invariant: false
+      #    transform: []        
 
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "RH"
@@ -69,27 +69,27 @@ climate_models:
       #  transform: []
   
 
- # - _target_: nc2pt.climatedata.ClimateModel
- #   info: "Low resolution ERA5, Western Canada"
- #   name: lr
- #   hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
- #     _target_: nc2pt.climatedata.ClimateVariable
- #     name: "hr_ref"
- #     alternative_names: ["T2"]
- #     path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
- #     is_west_negative: true
- #     invariant: true
+  # - _target_: nc2pt.climatedata.ClimateModel
+  #   info: "Low resolution ERA5, Western Canada"
+  #   name: lr
+  #   hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
+  #     _target_: nc2pt.climatedata.ClimateVariable
+  #     name: "hr_ref"
+  #     alternative_names: ["T2"]
+  #     path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
+  #     is_west_negative: true
+  #     invariant: true
 
- #   climate_variables:
- #      - _target_: nc2pt.climatedata.ClimateVariable
- #        name: "uas"
- #        alternative_names: ["U10", "u10", "uas"]
- #        path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
- #        is_west_negative: false
- #        apply_standardize: false
- #        apply_normalize: true
- #        invariant: false
- #        transform: []
+  #   climate_variables:
+  #       - _target_: nc2pt.climatedata.ClimateVariable
+  #         name: "uas"
+  #         alternative_names: ["U10", "u10", "uas"]
+  #         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+  #         is_west_negative: false
+  #         apply_standardize: false
+  #         apply_normalize: true
+  #         invariant: false
+  #         transform: []
   
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "pr"
@@ -114,14 +114,14 @@ climate_models:
 #         invariant: false
 #         transform: []
 
-#       - _target_: nc2pt.climatedata.ClimateVariable
-#         name: "vas"
-#         alternative_names: ["V10", "v10", "vas"]
-#         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
-#         apply_standardize: false
-#         apply_normalize: true
-#         invariant: false
-#         transform: []
+  # - _target_: nc2pt.climatedata.ClimateVariable
+  #   name: "vas"
+  #   alternative_names: ["V10", "v10", "vas"]
+  #   path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/vas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+  #   apply_standardize: false
+  #   apply_normalize: true
+  #   invariant: false
+  #   transform: []
 
 #      - _target_: nc2pt.climatedata.ClimateVariable
 #        name: "tas"
@@ -137,17 +137,33 @@ climate_models:
 
   - _target_: nc2pt.climatedata.ClimateModel
     name: hr_invariant
-    info: "Static invariant fields for WRF domain"
+    info: "HR static invariant fields for WRF domain"
     engine: netcdf4
     climate_variables:
       - _target_: nc2pt.climatedata.ClimateVariable
-        name: "HGT"
+        name: "topography"
         alternative_names: ["HGT", "elevation"]
         path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/CA4km_const.nc
         is_west_negative: false
         invariant: true
         apply_standardize: false
-        apply_normalize: false
+        apply_normalize: true
+        transform: []
+
+  - _target_: nc2pt.climatedata.ClimateModel
+    name: lr_invariant
+    info: "HR static invariant fields for WRF domain to be downsampled to LR"
+    engine: netcdf4
+    downsample: true
+    climate_variables:
+      - _target_: nc2pt.climatedata.ClimateVariable
+        name: "topography"
+        alternative_names: ["HGT"]
+        path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/CA4km_const.nc
+        is_west_negative: false
+        invariant: true
+        apply_standardize: false
+        apply_normalize: true
         transform: []
 
 

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -14,10 +14,10 @@
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
 output_path: /home/sbeairsto/data-sbeairsto/vancouver_island
 climate_models:
-  - _target_: nc2pt.climatedata.ClimateModel
-    name: hr
-    info: "High Resolution USask WRF, Western Canada"
-    climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
+  #- _target_: nc2pt.climatedata.ClimateModel
+  #  name: hr
+  #  info: "High Resolution USask WRF, Western Canada"
+  #  climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "pr"
       #   alternative_names: ["PREC"]
@@ -28,15 +28,15 @@ climate_models:
       #   invariant: false
       #   transform: []
 
-       - _target_: nc2pt.climatedata.ClimateVariable
-         name: "uas"
-         alternative_names: ["U10", "u10", "uas"]
-         path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
-         is_west_negative: true
-         apply_standardize: false
-         apply_normalize: true
-         invariant: false
-         transform: []
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "uas"
+      #   alternative_names: ["U10", "u10", "uas"]
+      #   path: /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/U10/*.nc
+      #   is_west_negative: true
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: []
 
   #     - _target_: nc2pt.climatedata.ClimateVariable
   #       name: "vas"

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -69,27 +69,27 @@ climate_models:
       #  transform: []
   
 
-  - _target_: nc2pt.climatedata.ClimateModel
-    info: "Low resolution ERA5, Western Canada"
-    name: lr
-    hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
-      _target_: nc2pt.climatedata.ClimateVariable
-      name: "hr_ref"
-      alternative_names: ["T2"]
-      path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
-      is_west_negative: true
-      invariant: true
+ # - _target_: nc2pt.climatedata.ClimateModel
+ #   info: "Low resolution ERA5, Western Canada"
+ #   name: lr
+ #   hr_ref: # Reference field to interpolate to. Will need to provide new file if not using USask WRF
+ #     _target_: nc2pt.climatedata.ClimateVariable
+ #     name: "hr_ref"
+ #     alternative_names: ["T2"]
+ #     path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
+ #     is_west_negative: true
+ #     invariant: true
 
-    climate_variables:
-       - _target_: nc2pt.climatedata.ClimateVariable
-         name: "uas"
-         alternative_names: ["U10", "u10", "uas"]
-         path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
-         is_west_negative: false
-         apply_standardize: false
-         apply_normalize: true
-         invariant: false
-         transform: []
+ #   climate_variables:
+ #      - _target_: nc2pt.climatedata.ClimateVariable
+ #        name: "uas"
+ #        alternative_names: ["U10", "u10", "uas"]
+ #        path: /net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/uas_1hr_ERA5_an_RDA-025_1979010100-2018123123.nc
+ #        is_west_negative: false
+ #        apply_standardize: false
+ #        apply_normalize: true
+ #        invariant: false
+ #        transform: []
   
       # - _target_: nc2pt.climatedata.ClimateVariable
       #   name: "pr"
@@ -136,8 +136,9 @@ climate_models:
 
 
   - _target_: nc2pt.climatedata.ClimateModel
-    name: invariant
+    name: hr_invariant
     info: "Static invariant fields for WRF domain"
+    engine: netcdf4
     climate_variables:
       - _target_: nc2pt.climatedata.ClimateVariable
         name: "HGT"
@@ -157,12 +158,12 @@ dims: # Defines the dimensions of the dataset and lists them to be initialized a
     chunksize: 100
   - _target_: nc2pt.climatedata.ClimateDimension
     name: rlat
-    alternative_names: ["rotated_latitude"]
+    alternative_names: ["rotated_latitude", "south_north"]
     hr_only: true
     chunksize: -1
   - _target_: nc2pt.climatedata.ClimateDimension
     name: rlon
-    alternative_names: ["rotated_longitude"]
+    alternative_names: ["rotated_longitude", "west_east"]
     hr_only: true
     chunksize: -1
   - _target_: nc2pt.climatedata.ClimateDimension

--- a/nc2pt/conf/config.yaml
+++ b/nc2pt/conf/config.yaml
@@ -12,21 +12,21 @@
 # _target_ is loaded as a dataclass in climatedata.py with some inheritance.
 
 _target_: nc2pt.climatedata.ClimateData # Iniatlizes ClimateData dataclass object
-output_path: /path/to/my/data/folder
+output_path: /home/sbeairsto/data-sbeairsto/vancouver_island
 climate_models:
   - _target_: nc2pt.climatedata.ClimateModel
     name: hr
     info: "High Resolution USask WRF, Western Canada"
     climate_variables: # Provides a list of ClimateVariable dataclass objects to initialize
-       - _target_: nc2pt.climatedata.ClimateVariable
-         name: "pr"
-         alternative_names: ["PREC"]
-         path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
-         is_west_negative: true
-         apply_standardize: false
-         apply_normalize: true
-         invariant: false
-         transform: []
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "pr"
+      #   alternative_names: ["PREC"]
+      #   path:  /net/venus/kenes/downloaded-data/acannon/USask-WRF-WCA/pgw-wrf-wca/PREC/*.nc
+      #   is_west_negative: true
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: []
 
        - _target_: nc2pt.climatedata.ClimateVariable
          name: "uas"
@@ -76,7 +76,7 @@ climate_models:
       _target_: nc2pt.climatedata.ClimateVariable
       name: "hr_ref"
       alternative_names: ["T2"]
-      path: /home/my_username/nc2pt/nc2pt/data/hr_ref.nc
+      path: /home/sbeairsto/projects/nc2pt/nc2pt/data/hr_ref.nc
       is_west_negative: true
       invariant: true
 
@@ -91,15 +91,15 @@ climate_models:
          invariant: false
          transform: []
   
-       - _target_: nc2pt.climatedata.ClimateVariable
-         name: "pr"
-         alternative_names: ["PREC"]
-         path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
-         is_west_negative: false
-         apply_standardize: false
-         apply_normalize: true
-         invariant: false
-         transform: ["x * 3600"]
+      # - _target_: nc2pt.climatedata.ClimateVariable
+      #   name: "pr"
+      #   alternative_names: ["PREC"]
+      #   path: '/net/venus/kenes/downloaded-data/acannon/ERA5_NCAR-RDA_North_America/1hr/pr_1hr_ERA5_fc_RDA-025_1979010106-2019010106.nc'
+      #   is_west_negative: false
+      #   apply_standardize: false
+      #   apply_normalize: true
+      #   invariant: false
+      #   transform: ["x * 3600"]
          #  - "x * 3600"
 
 # # for some reason, the way RH was written to file requires time chunks be explicitly defined in io.py.
@@ -177,16 +177,16 @@ select:
     # Crop to the dataset with the shortest run
     # this defines the full dataset from which to subset
     range:
-      start: "20001001T06:00:00"
-      end: "20150928T12:00:00"
+      start: "20010101T00:00:00"
+      end: "20031231T23:00:00"
       # start: "2021-11-01T00:00:00"
       # end: "2021-12-31T22:00:00"
 
     # use this to select which years to reserve for testing
     # and for validation
     # the remaining years in full will be used for training
-    test_years: [2000, 2009, 2014]
-    validation_years: [2015]
+    test_years: [2001]
+    validation_years: [2002]
     # test_years: [None]
     # validation_years: [None]
 
@@ -194,11 +194,11 @@ select:
   spatial:
     scale_factor: 8
     x:
-      first_index: 110
-      last_index: 622
+      first_index: 100
+      last_index: 228
     y:
-      first_index: 20
-      last_index: 532
+      first_index: 0
+      last_index: 128
 
 
 

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -1,6 +1,6 @@
 import logging
 from hydra.utils import instantiate
-from typing import Union
+from typing import Union, List
 from nc2pt.climatedata import ClimateDimension, ClimateVariable, ClimateData
 import xarray as xr
 
@@ -63,7 +63,8 @@ def configure_metadata(
                 ds = ds.squeeze(k).drop_vars(k)
 
     ds = rename_keys(ds, outcome_obj=var, ds_attr="data_vars")
-    ds = drop_unused_variables(ds, var)
+    preserve = [dim.name for dim in climdata.dims] + [coord.name for coord in climdata.coords]
+    ds = drop_unused_variables(ds, var, preserve_vars=preserve)
     ds = match_longitudes(ds) if var.is_west_negative else ds
 
     return ds
@@ -163,40 +164,48 @@ def flatten_2D_forecast_time(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
-def drop_unused_variables(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
+def drop_unused_variables(
+    ds: xr.Dataset,
+    var: ClimateVariable,
+    preserve_vars: List[str]
+) -> xr.Dataset:
     """
-    Drop all variables from the dataset except the one declared in the ClimateVariable object.
+    Drop all data variables from the dataset except the one declared in the ClimateVariable object
+    and any variables explicitly listed to be preserved (e.g., dimensions and coordinates).
 
     Parameters
     ----------
     ds : xr.Dataset
         The dataset potentially containing multiple variables.
     var : ClimateVariable
-        The ClimateVariable object specifying the intended variable to keep,
-        identified by its canonical `name`.
+        The ClimateVariable object specifying the intended variable to keep.
+    preserve_vars : List[str]
+        A list of variable names to retain in addition to the main variable (e.g., time, lat, lon).
 
     Returns
     -------
     xr.Dataset
-        A dataset containing only the specified variable.
+        A filtered dataset containing only the target variable and the preserved variables.
 
     Logs
     ----
-    Logs a message listing how many dropped variables, if any.
+    Logs a message listing all dropped variables, if any.
 
     Raises
     ------
     KeyError
-        If the target variable does not exist in the dataset.
+        If the target variable is not found in the dataset.
     """
     if var.name not in ds:
         raise KeyError(f"Declared variable '{var.name}' not found in dataset variables: {list(ds.variables)}")
 
+    keep_vars = {var.name, *preserve_vars}
     all_vars = set(ds.variables)
-    ds = ds[[var.name]]
-    dropped = all_vars - {var.name}
+    to_drop = all_vars - keep_vars
 
-    if dropped:
-        logging.info(f"Dropping {len(dropped)} unused climate variables from dataset.")
+    if to_drop:
+        logging.info(f"Dropping unused variables from {var.path}: {sorted(to_drop)}")
+
+    ds = ds.drop_vars(to_drop, errors="ignore")
 
     return ds

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -197,6 +197,6 @@ def drop_unused_variables(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
     dropped = all_vars - {var.name}
 
     if dropped:
-        logging.info(f"Dropping {len(dropped)} unused variables from dataset.")
+        logging.info(f"Dropping {len(dropped)} unused climate variables from dataset.")
 
     return ds

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -63,6 +63,7 @@ def configure_metadata(
                 ds = ds.squeeze(k).drop_vars(k)
 
     ds = rename_keys(ds, outcome_obj=var, ds_attr="data_vars")
+    ds = drop_unused_variables(ds, var)
     ds = match_longitudes(ds) if var.is_west_negative else ds
 
     return ds
@@ -159,4 +160,43 @@ def flatten_2D_forecast_time(ds: xr.Dataset) -> xr.Dataset:
     ds = ds.drop_vars(["time", "forecast_initial_time", "forecast_hour"])
     ds = ds.assign_coords(time=("time", valid_time.values.ravel()))
     ds = ds.assign_coords(time=("time", valid_time.values.ravel()))
+    return ds
+
+
+def drop_unused_variables(ds: xr.Dataset, var: ClimateVariable) -> xr.Dataset:
+    """
+    Drop all variables from the dataset except the one declared in the ClimateVariable object.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset potentially containing multiple variables.
+    var : ClimateVariable
+        The ClimateVariable object specifying the intended variable to keep,
+        identified by its canonical `name`.
+
+    Returns
+    -------
+    xr.Dataset
+        A dataset containing only the specified variable.
+
+    Logs
+    ----
+    Logs a message listing how many dropped variables, if any.
+
+    Raises
+    ------
+    KeyError
+        If the target variable does not exist in the dataset.
+    """
+    if var.name not in ds:
+        raise KeyError(f"Declared variable '{var.name}' not found in dataset variables: {list(ds.variables)}")
+
+    all_vars = set(ds.variables)
+    ds = ds[[var.name]]
+    dropped = all_vars - {var.name}
+
+    if dropped:
+        logging.info(f"Dropping {len(dropped)} unused variables from dataset.")
+
     return ds

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -42,8 +42,9 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
     for climate_variable in model.climate_variables:
         # Instantiates climate_variable object in cliamtedata.py
         climate_variable = instantiate(climate_variable)
+        engine = model.engine or climdata.compute.engine
 
-        ds = load_grid(climate_variable.path, engine=climdata.compute.engine)
+        ds = load_grid(climate_variable.path, engine=engine)
 
         start = timer()
         logging.info(

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,7 +1,7 @@
 from nc2pt.metadata import configure_metadata
 from nc2pt.io import load_grid, write_to_zarr
 from nc2pt.align import align_with_lr, crop_field, slice_time
-from nc2pt.computations import split_and_standardize, user_defined_transform
+from nc2pt.computations import split_and_standardize, standardize_or_normalize
 from nc2pt.climatedata import ClimateData, ClimateModel
 
 import logging
@@ -91,6 +91,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
                 )
 
         else:
+            ds = standardize_or_normalize(ds, climate_variable)
             logging.info("✨ Writing output...")
             write_to_zarr(
                 climdata.apply_chunks(ds),

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -75,6 +75,13 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
                 x=climdata.select.spatial.x,
                 y=climdata.select.spatial.y,
             ),
+            "lr_invariant": partial(
+                crop_field,
+                scale_factor=climdata.select.spatial.scale_factor,
+                x=climdata.select.spatial.x,
+                y=climdata.select.spatial.y,
+                downsample=getattr(model, "downsample", False),
+            ),
         }
 
         # This implies that it is a different grid or a lr dataset.

--- a/nc2pt/tools/zarr_to_torch.py
+++ b/nc2pt/tools/zarr_to_torch.py
@@ -34,23 +34,51 @@ def loop_over_variables(climate_data, model, var, s):
     dims = [instantiate(dim) for dim in climate_data.dims]
     chunks = {dim.name: dim.chunksize for dim in dims}
 
-    with xr.open_zarr(
-        f"{output_path}/{var.name}_{s}_{model.name}.zarr/", chunks=chunks
-    ) as ds:
+    output_subfolder = "invariant" if s is None else s
+
+    if s is None:
+        zarr_path = f"{output_path}/{var.name}_{model.name}.zarr/"
+    else:
+        zarr_path = f"{output_path}/{var.name}_{s}_{model.name}.zarr/"
+
+    with xr.open_zarr(zarr_path, chunks=chunks) as ds:
+
+        # Handle invariant variable
+        if "time" not in ds.dims or getattr(var, "invariant", False):
+            logging.info(f"{var.name} is invariant. Saving without time slicing.")
+            make_dirs(output_path, output_subfolder, var.name, model.name)
+
+            path = f"{output_path}/{output_subfolder}/{var.name}/{model.name}/{var.name}.pt"
+            arr = ds[var.name].values
+            x = torch.tensor(np.array(arr))
+            assert not torch.isnan(x).any(), f"NaNs found in {var.name}"
+            torch.save(x, path)
+
+            # Save attributes
+            attrs = ds[var.name].attrs
+            attrs_file = Path(
+                f"{output_path}/{output_subfolder}/{var.name}/{model.name}/{var.name}_attrs.yaml"
+            )
+            with open(attrs_file, "w") as f:
+                f.write("attributes:\n")
+                for key, value in attrs.items():
+                    f.write(f"  {key}: {value}\n")
+            return
+
         ds = ds.sortby("time")
         # Create parent dir if it doesn't exist for each variable
-        make_dirs(output_path, s, var.name, model.name)
+        make_dirs(output_path, output_subfolder, var.name, model.name)
         indices = ds.time.dt.strftime("%Y-%m-%d-%H").values
-
+        
         partial_paths = [
-            f"{output_path}/{s}/{var.name}/{model.name}/{var.name}_{i}.pt"
+            f"{output_path}/{output_subfolder}/{var.name}/{model.name}/{var.name}_{i}.pt"
             for i in indices
         ]
 
         pool_tuple = zip(
             indices,
             partial_paths,
-            ds[var.name].transpose(*chunks.keys()),
+            ds[var.name].transpose(*[dim for dim in chunks.keys() if dim in ds[var.name].dims]),
         )
 
         progress_starmap(
@@ -58,10 +86,11 @@ def loop_over_variables(climate_data, model, var, s):
         )
 
 
-def loop_over_sets(climate_data, model, s):
+def loop_over_sets(climate_data, model, s: str = None):
     model = instantiate(model)
+    label = s if s else "invariant"
 
-    logging.info(f"Loading {s} {model.name} dataset...")
+    logging.info(f"Loading {label} {model.name} dataset...")
     for var in model.climate_variables:
         logging.info(f"Processing {var.name} variable...")
         if s == "train":
@@ -91,9 +120,13 @@ def main(climate_data) -> None:
     for model in climate_data.climate_models:
         start = timer()
 
-        partial_set_loop = partial(loop_over_sets, climate_data, model)
-        for s in ["train", "test", "validation"]:
-            partial_set_loop(s)
+        if all(getattr(var, "invariant", False) for var in model.climate_variables):
+            logging.info(f"Processing invariant model: {model.name}")
+            loop_over_sets(climate_data, model, s=None)
+        else:
+            partial_set_loop = partial(loop_over_sets, climate_data, model)
+            for s in ["train", "test", "validation"]:
+                partial_set_loop(s)
 
         end = timer()
         logging.info(f"Finished {model.name} dataset in {timedelta(seconds=end-start)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ netCDF4
 hydra-core==1.3.2
 h5netcdf
 torch
-distriubted
+distributed


### PR DESCRIPTION
# 🚀 Add full support for HR and LR invariant field preprocessing and alignment
This PR adds robust functionality to handle invariant (time-independent) climate fields throughout the preprocessing pipeline. It enables the system to ingest high-resolution invariant fields (e.g., topography from WRF), apply cropping and downsampling operations, and save them in both HR and LR aligned formats compatible with the model structure.

## ✅ Summary of Major Features
### 🧭 High-Resolution Invariant Field Support
- High-resolution invariant fields (e.g., HGT, LANDMASK, etc. from WRF constant files) can now be included as a separate `ClimateModel` (e.g., `hr_invariant`) in the config.

- These fields are cropped according to the standard spatial selection logic (`scale_factor`, `x`, `y`).

- Fields are written out as `.zarr` datasets and converted to `.pt` format during torch preprocessing, just like time-varying fields — but without train/val/test splits.

### 📉 Low-Resolution Invariant Downsampling
- Low-resolution invariant fields (e.g., for conditioning in LR models) can now be generated directly from the high-resolution invariant fields via configurable downsampling.

- A new `downsample: true` flag at the `ClimateMode`l level triggers `.coarsen(...).mean()` using the same `scale_factor` as the cropping logic.


### ⚙️ Config-Based Integration
- Invariant support is fully integrated with the existing Hydra config system.
- To add a new HR or LR invariant model, simply define a `ClimateModel` block with: 
  - `invariant: true` on each `ClimateVariable`
  - `downsample: true` on the model if applicable

No code changes are needed per variable — the alignment and downsampling logic is handled uniformly.

### 📁 Output Structure
HR invariant fields:

```
output_path/
  invariant/
    topography/
      hr_invariant/
        topography.pt
        topography_attrs.yaml
```

LR invariant fields (downsampled):
```
output_path/
  invariant/
    topography/
      lr_invariant/
        topography.pt
        topography_attrs.yaml
```

## 🧪 Testing
Tested successfully on the following configurations:

- ✅ HR time-varying variable: `uas`

- ✅ LR time-varying variable: `uas`

- ✅ HR invariant field: topography (`HGT` from `CA4km_const.nc`)

- ✅ LR invariant field: downsampled topography

Explored full `CA4km_const.nc` file — logic should handle all fields contained therein.

## 📌 Notes & Next Steps
- This lays the foundation for integrating invariant fields into both training and inference workflows (e.g., topography-aware downscaling).

- Future enhancements could include support for:

   - Downsampling with configurable methods (mean, median, etc.)

   - Interpolation-based alignment with arbitrary grids (e.g., when invariant fields and HR/LR grids differ in projection)