### PR TITLE
Log standardization stats

### DIFF
--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -1,3 +1,7 @@
+import json
+import hashlib
+from datetime import datetime
+from pathlib import Path
 import logging
 from hydra.utils import instantiate
 from typing import Union, List
@@ -15,6 +19,160 @@ class MissingKey(Exception):
     """Raised when a variable is missing from the dataset."""
 
     pass
+
+
+class NormalizerMetadataCollector:
+    """
+    Collects and writes normalization or standardization metadata for climate variables.
+
+    Tracks attributes like min/max or mean/std, units, transforms, and spatial settings
+    for each variable after standardization/normalization is applied. Saves the metadata
+    to per-variable JSON files with a content hash for reproducibility and validation.
+    """
+
+    def __init__(self, output_dir: str):
+        """
+        Initialize the collector and create the output directory.
+
+        Args:
+            output_dir: Directory where normalization JSON files will be written.
+        """
+        self.metadata = {}
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        logging.info(f"📁 NormalizerMetadataCollector initialized with output dir: {self.output_dir}")
+
+    def _compute_hash(self, data: dict) -> str:
+        """
+        Compute a SHA256 hash of the metadata dictionary (excluding the 'hash' field).
+
+        Args:
+            data: Dictionary to hash.
+
+        Returns:
+            SHA256 hash string.
+        """
+        temp = {k: v for k, v in data.items() if k != "hash"}
+        temp_json = json.dumps(temp, sort_keys=True)
+        return hashlib.sha256(temp_json.encode()).hexdigest()
+
+    def _extract_stats(self, variable: ClimateVariable, attrs: dict) -> dict:
+        """
+        Extract normalization or standardization statistics from xarray attributes.
+
+        Args:
+            variable: The ClimateVariable being processed.
+            attrs: The attributes from the xarray variable.
+
+        Returns:
+            A dictionary containing method and statistics (min/max or mean/std).
+        """
+        if variable.apply_normalize:
+            return {
+                "method": "minmax",
+                "min": float(attrs["min"]),
+                "max": float(attrs["max"]),
+            }
+        elif variable.apply_standardize:
+            return {
+                "method": "standard",
+                "mean": float(attrs["mean"]),
+                "std": float(attrs["std"]),
+            }
+        return {}
+
+    def _get_spatial_crop(self, climate_data: ClimateData) -> dict:
+        """
+        Retrieve the spatial crop bounds from the config.
+
+        Args:
+            climate_data: Full ClimateData config object.
+
+        Returns:
+            Dict with x and y crop bounds.
+        """
+        spatial_cfg = climate_data.select["spatial"]
+        return {
+            "x": [spatial_cfg["x"]["first_index"], spatial_cfg["x"]["last_index"]],
+            "y": [spatial_cfg["y"]["first_index"], spatial_cfg["y"]["last_index"]],
+        }
+
+    def _get_hr_ref_path(self, climate_data: ClimateData, model_name: str) -> str:
+        """
+        Look up the HR reference field path from the model config.
+
+        Args:
+            climate_data: Full ClimateData config.
+            model_name: Name of the model (e.g., 'lr').
+
+        Returns:
+            The path to the HR reference field, or None.
+        """
+        for model in climate_data.climate_models:
+            if model.name == model_name and model.hr_ref is not None:
+                return model.hr_ref.path
+        return None
+
+    def add_variable_from_config(
+        self,
+        climate_data: ClimateData,
+        climate_variable: ClimateVariable,
+        processed_ds: xr.Dataset,
+        model_name: str,
+    ):
+        """
+        Add metadata for a single climate variable after it's been normalized or standardized.
+
+        Args:
+            climate_data: Full ClimateData config object.
+            climate_variable: The ClimateVariable being processed.
+            processed_ds: xarray.Dataset that contains processed data for this variable.
+            model_name: Name of the model this variable belongs to (e.g., 'lr').
+        """
+        var_name = climate_variable.name
+        attrs = processed_ds[var_name].attrs
+
+        stats = self._extract_stats(climate_variable, attrs)
+        if not stats:
+            logging.info(f"⚠️  Skipping variable '{var_name}': not scaled.")
+            return
+
+        units = attrs.get("units", "unknown")
+        logging.info(f"📦 Adding metadata for variable: {var_name}")
+
+        self.metadata[var_name] = {
+            "variable": var_name,
+            **stats,
+            "units": {
+                "original": units,
+                "post_transform": units  # Extend later if needed
+            },
+            "apply_normalize": climate_variable.apply_normalize,
+            "apply_standardize": climate_variable.apply_standardize,
+            "transforms": climate_variable.transform or [],
+            "is_west_negative": climate_variable.is_west_negative,
+            "spatial_scale_factor": climate_data.select["spatial"]["scale_factor"],
+            "spatial_crop": self._get_spatial_crop(climate_data),
+            "hr_reference_field": self._get_hr_ref_path(climate_data, model_name),
+            "created": datetime.utcnow().isoformat() + "Z"
+        }
+
+    def write_all(self):
+        """
+        Write each variable's metadata to a JSON file in the output directory.
+        Adds a hash field for traceability.
+        """
+        if not self.metadata:
+            logging.warning("⚠️ No metadata to write.")
+            return
+
+        for var_name, meta in self.metadata.items():
+            meta["hash"] = self._compute_hash(meta)
+            out_path = self.output_dir / f"{var_name}_normalization_metadata.json"
+            logging.info(f"📝 Writing metadata for '{var_name}' to {out_path}")
+            with out_path.open("w") as f:
+                json.dump(meta, f, indent=2)
+            logging.info(f"✅ Wrote: {out_path}")
 
 
 def configure_metadata(

--- a/nc2pt/metadata.py
+++ b/nc2pt/metadata.py
@@ -113,6 +113,30 @@ class NormalizerMetadataCollector:
                 return model.hr_ref.path
         return None
 
+    def log_variable_units_from_dataset(self, variable_name: str, ds: xr.Dataset) -> None:
+        """
+        Extract and log the original units for a given variable from a dataset.
+
+        This should be called early in the workflow, before normalization or 
+        standardization is applied. It stores the 'original' units in the metadata, 
+        and leaves 'post_transform' as 'unknown' for now.
+
+        Args:
+            variable_name (str): Name of the climate variable (e.g., 'uas').
+            ds (xarray.Dataset): Dataset containing the variable.
+        """
+        units = ds[variable_name].attrs.get("units", "unknown")
+        logging.info(f"Extracted units for variable '{variable_name}': {units}")
+
+        if variable_name not in self.metadata:
+            self.metadata[variable_name] = {
+                "units": {"original": units, "post_transform": "unknown"}
+            }
+        else:
+            self.metadata[variable_name].setdefault("units", {})
+            self.metadata[variable_name]["units"]["original"] = units
+            self.metadata[variable_name]["units"].setdefault("post_transform", "unknown")
+
     def add_variable_from_config(
         self,
         climate_data: ClimateData,
@@ -137,16 +161,13 @@ class NormalizerMetadataCollector:
             logging.info(f"⚠️  Skipping variable '{var_name}': not scaled.")
             return
 
-        units = attrs.get("units", "unknown")
         logging.info(f"📦 Adding metadata for variable: {var_name}")
 
-        self.metadata[var_name] = {
+        self.metadata.setdefault(var_name, {})  # Preserve existing entries like "units"
+
+        self.metadata[var_name].update({
             "variable": var_name,
             **stats,
-            "units": {
-                "original": units,
-                "post_transform": units  # Extend later if needed
-            },
             "apply_normalize": climate_variable.apply_normalize,
             "apply_standardize": climate_variable.apply_standardize,
             "transforms": climate_variable.transform or [],
@@ -154,8 +175,13 @@ class NormalizerMetadataCollector:
             "spatial_scale_factor": climate_data.select["spatial"]["scale_factor"],
             "spatial_crop": self._get_spatial_crop(climate_data),
             "hr_reference_field": self._get_hr_ref_path(climate_data, model_name),
-            "created": datetime.utcnow().isoformat() + "Z"
-        }
+            "created": datetime.utcnow().isoformat() + "Z",
+        })
+
+        # Ensure 'units' dict exists and has both keys set
+        self.metadata[var_name].setdefault("units", {})
+        self.metadata[var_name]["units"].setdefault("original", "unknown")
+        self.metadata[var_name]["units"].setdefault("post_transform", "unknown")
 
     def write_all(self):
         """

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -12,8 +12,6 @@ import hydra
 from hydra.utils import instantiate
 from dask.distributed import Client
 import dask
-import cProfile
-import pstats
 
 
 def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
@@ -137,5 +135,4 @@ def start(climate_data) -> None:
 
 if __name__ == "__main__":
     with dask.config.set(**{"array.slicing.split_large_chunks": False}):
-        with cProfile.Profile() as pr:
-            start()
+        start()

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -1,4 +1,4 @@
-from nc2pt.metadata import configure_metadata
+from nc2pt.metadata import configure_metadata, NormalizerMetadataCollector
 from nc2pt.io import load_grid, write_to_zarr
 from nc2pt.align import align_with_lr, crop_field, slice_time
 from nc2pt.computations import split_and_standardize, standardize_or_normalize
@@ -12,6 +12,8 @@ import hydra
 from hydra.utils import instantiate
 from dask.distributed import Client
 import dask
+import cProfile
+import pstats
 
 
 def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
@@ -29,6 +31,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
     """
 
     configure_metadata_fn = partial(configure_metadata, climdata=climdata)
+    metadata_collector = NormalizerMetadataCollector(climdata.output_path)
     alignment_procedures = {}
     if model.hr_ref is not None:
         hr_ref = load_grid(model.hr_ref.path, engine=climdata.compute.engine)
@@ -90,6 +93,10 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
             train_test_validation_ds = split_and_standardize(
                 ds, climdata, climate_variable
             )
+            metadata_collector.add_variable_from_config(climate_data=climdata,
+                                                        climate_variable=climate_variable,
+                                                        processed_ds=train_test_validation_ds["train"],
+                                                        model_name=model.name)
             for train_test_validation in train_test_validation_ds:
                 logging.info(f"✨ Writing {train_test_validation} output...")
                 write_to_zarr(
@@ -109,6 +116,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         logging.info(f"🎉 Done processing {climate_variable.name} in {model.info}!")
         logging.info(f"⏳ Time elapsed ⏳: {timedelta(seconds=end-start)}")
         del ds
+    metadata_collector.write_all()
 
 
 def preprocess(climdata: ClimateData) -> None:
@@ -129,4 +137,5 @@ def start(climate_data) -> None:
 
 if __name__ == "__main__":
     with dask.config.set(**{"array.slicing.split_large_chunks": False}):
-        start()
+        with cProfile.Profile() as pr:
+            start()

--- a/nc2pt/preprocess.py
+++ b/nc2pt/preprocess.py
@@ -53,6 +53,7 @@ def preprocess_variables(model: ClimateModel, climdata: ClimateData) -> None:
         )
 
         ds = configure_metadata_fn(ds, climate_variable)
+        metadata_collector.log_variable_units_from_dataset(climate_variable.name, ds)
         ds = climdata.apply_chunks(ds)
 
         ds = (


### PR DESCRIPTION

### 🚀 PR: Add `NormalizerMetadataCollector` for Emulation Metadata Logging

**Summary:**  
This PR introduces the `NormalizerMetadataCollector`, a utility class for tracking and saving metadata related to normalization or standardization of climate variables during preprocessing. Each variable's metadata is saved as a standalone `.json` file with an embedded content hash for validation and reproducibility.

----------

### ✅ Features

-   📦 **Tracks per-variable metadata**:
    
    -   `min`/`max` for min-max normalization
        
    -   `mean`/`std` for standardization
        
    -   `units`, `transforms`, `spatial_crop`, etc.
        
-   🧠 **Pulls context from existing config**:
    
    -   Uses `ClimateData` and `ClimateVariable` objects
        
    -   Infers spatial crop and HR reference path
        
-   🔐 **Computes SHA256 hash** of the metadata dictionary (excluding the hash field itself)
    
-   📄 **Writes one JSON file per variable** in a specified output directory
    
-   🪵 **Includes logging** at all major steps (skip reason, add, write)
    

----------

### 🧪 Example Output (`uas_normalization.json`)

```json
{  "variable":  "uas",
"method":  "minmax",
"min":  -17.88,
"max":  20.89,
"units":  {  "original":  "unknown",  "post_transform":  "unknown"  },
"apply_normalize":  true,
"apply_standardize":  false,
"transforms":  [],
"is_west_negative":  false,
"spatial_scale_factor":  8,
"spatial_crop":  {  "x":  [100,  228],  "y":  [0,  128]  },
"hr_reference_field":  "~/projects/nc2pt/nc2pt/data/hr_ref.nc",
"created":  "2025-06-09T19:26:17.623063Z",
"hash":  "c101f41a4976c5b9fb0e2ded8cebc7fff9ae6d2fa4ff06d00dc36696fe27d40c"  }
```
----------

### 🧩 Usage

Typical integration into the preprocessing pipeline (after standardization or normalization):

``` python
collector.add_variable_from_config(
    climate_data=climdata,
    climate_variable=var,
    processed_ds=train_ds,
    model_name="lr" )
collector.write_all()
```

----------

### 📌 Next Steps

-   Use these `.json` files in the inference pipeline to un-normalize model output
    
-  Validate against model-embedded metadata (e.g. TorchScript hash)